### PR TITLE
feat: Support properties that return AsReadOnly instances

### DIFF
--- a/src/AutoFakerBinder.cs
+++ b/src/AutoFakerBinder.cs
@@ -326,6 +326,10 @@ public class AutoFakerBinder : IAutoFakerBinder
             return;
 
         object? instance = member.Getter(parent);
+
+        if (instance is IDictionary { IsReadOnly: true })
+            return;
+        
         CachedType[] argTypes = member.CachedType.GetAddMethodArgumentTypes();
         CachedMethod? addMethod = GetAddMethod(member.CachedType, argTypes);
 
@@ -345,7 +349,7 @@ public class AutoFakerBinder : IAutoFakerBinder
 
         object? instance = member.Getter(parent);
 
-        if (instance is IList { IsReadOnly: true } or IDictionary { IsReadOnly: true })
+        if (instance is IList { IsReadOnly: true })
             return;
 
         CachedType[] argTypes = member.CachedType.GetAddMethodArgumentTypes();

--- a/src/AutoFakerBinder.cs
+++ b/src/AutoFakerBinder.cs
@@ -344,6 +344,10 @@ public class AutoFakerBinder : IAutoFakerBinder
             return;
 
         object? instance = member.Getter(parent);
+
+        if (instance is IList { IsReadOnly: true } or IDictionary { IsReadOnly: true })
+            return;
+
         CachedType[] argTypes = member.CachedType.GetAddMethodArgumentTypes();
         CachedMethod? addMethod = GetAddMethod(member.CachedType, argTypes);
 

--- a/test/Soenneker.Utils.AutoBogus.Tests/AutoFaker{T}Tests.cs
+++ b/test/Soenneker.Utils.AutoBogus.Tests/AutoFaker{T}Tests.cs
@@ -194,7 +194,8 @@ public class AutoFakerTTests
             TestClassICollectionPropertyWrappedWithReadOnly obj = objectToFake.Generate();
 
             writer.ToString().Should().BeEmpty();
-            obj.Collection.Should().BeEmpty();
+            obj.Collection.Should().NotBeEmpty();
+            obj.WrappedCollection.Should().BeEmpty();
         }
         finally
         {
@@ -223,7 +224,8 @@ public class AutoFakerTTests
             TestClassIDictionaryPropertyWrappedWithReadOnly obj = objectToFake.Generate();
 
             writer.ToString().Should().BeEmpty();
-            obj.Dictionary.Should().BeEmpty();
+            obj.Dictionary.Should().NotBeEmpty();
+            obj.WrappedDictionary.Should().BeEmpty();
         }
         finally
         {

--- a/test/Soenneker.Utils.AutoBogus.Tests/AutoFaker{T}Tests.cs
+++ b/test/Soenneker.Utils.AutoBogus.Tests/AutoFaker{T}Tests.cs
@@ -186,12 +186,20 @@ public class AutoFakerTTests
 
         var objectToFake = new AutoFaker<TestClassICollectionPropertyWrappedWithReadOnly>(config);
 
-        using var writer = new StringWriter();
-        Console.SetOut(writer);
-        TestClassICollectionPropertyWrappedWithReadOnly obj = objectToFake.Generate();
-        
-        writer.ToString().Should().BeEmpty();
-        obj.Collection.Should().BeEmpty();
+        TextWriter originalOut = Console.Out;
+        try
+        {
+            using var writer = new StringWriter();
+            Console.SetOut(writer);
+            TestClassICollectionPropertyWrappedWithReadOnly obj = objectToFake.Generate();
+
+            writer.ToString().Should().BeEmpty();
+            obj.Collection.Should().BeEmpty();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
     }
 
     [Fact]
@@ -207,12 +215,20 @@ public class AutoFakerTTests
 
         var objectToFake = new AutoFaker<TestClassIDictionaryPropertyWrappedWithReadOnly>(config);
 
-        using var writer = new StringWriter();
-        Console.SetOut(writer);
-        TestClassIDictionaryPropertyWrappedWithReadOnly obj = objectToFake.Generate();
+        TextWriter originalOut = Console.Out;
+        try
+        {
+            using var writer = new StringWriter();
+            Console.SetOut(writer);
+            TestClassIDictionaryPropertyWrappedWithReadOnly obj = objectToFake.Generate();
 
-        writer.ToString().Should().BeEmpty();
-        obj.Dictionary.Should().BeEmpty();
+            writer.ToString().Should().BeEmpty();
+            obj.Dictionary.Should().BeEmpty();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
     }
 
     [Fact]

--- a/test/Soenneker.Utils.AutoBogus.Tests/AutoFaker{T}Tests.cs
+++ b/test/Soenneker.Utils.AutoBogus.Tests/AutoFaker{T}Tests.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Soenneker.Utils.AutoBogus.Tests.Dtos.Complex;
 using System.Diagnostics;
+using System.IO;
 using Soenneker.Utils.AutoBogus.Tests.Dtos.Simple;
 using Xunit;
 using System.Linq;
@@ -169,6 +171,48 @@ public class AutoFakerTTests
         TestClassPrivateReadOnlyField? obj = objectToFake.Generate();
 
         obj.GetKey().Should().BeNull();
+    }
+
+    [Fact]
+    public void TestWrappedReadOnlyCollectionProperty_Should_not_be_set_by_AutoFaker()
+    {
+        var config = new AutoFakerConfig
+        {
+            ReflectionCacheOptions = new ReflectionCacheOptions
+            {
+                FieldFlags = BindingFlags.Public
+            }
+        };
+
+        var objectToFake = new AutoFaker<TestClassICollectionPropertyWrappedWithReadOnly>(config);
+
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        TestClassICollectionPropertyWrappedWithReadOnly obj = objectToFake.Generate();
+        
+        writer.ToString().Should().BeEmpty();
+        obj.Collection.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TestWrappedReadOnlyDictionaryProperty_Should_not_be_set_by_AutoFaker()
+    {
+        var config = new AutoFakerConfig
+        {
+            ReflectionCacheOptions = new ReflectionCacheOptions
+            {
+                FieldFlags = BindingFlags.Public
+            }
+        };
+
+        var objectToFake = new AutoFaker<TestClassIDictionaryPropertyWrappedWithReadOnly>(config);
+
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        TestClassIDictionaryPropertyWrappedWithReadOnly obj = objectToFake.Generate();
+
+        writer.ToString().Should().BeEmpty();
+        obj.Dictionary.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Soenneker.Utils.AutoBogus.Tests/Dtos/Simple/TestClassICollectionPropertyWrappedWithReadOnly.cs
+++ b/test/Soenneker.Utils.AutoBogus.Tests/Dtos/Simple/TestClassICollectionPropertyWrappedWithReadOnly.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Soenneker.Utils.AutoBogus.Tests.Dtos.Simple;
+
+public class TestClassICollectionPropertyWrappedWithReadOnly
+{
+    private readonly List<int> _collection = new();
+
+    public ICollection<int> Collection => _collection.AsReadOnly();
+}

--- a/test/Soenneker.Utils.AutoBogus.Tests/Dtos/Simple/TestClassICollectionPropertyWrappedWithReadOnly.cs
+++ b/test/Soenneker.Utils.AutoBogus.Tests/Dtos/Simple/TestClassICollectionPropertyWrappedWithReadOnly.cs
@@ -4,7 +4,13 @@ namespace Soenneker.Utils.AutoBogus.Tests.Dtos.Simple;
 
 public class TestClassICollectionPropertyWrappedWithReadOnly
 {
+    // Both fields are readonly but the collections can be modified.
     private readonly List<int> _collection = new();
+    private readonly List<int> _collectionToWrap = new();
 
-    public ICollection<int> Collection => _collection.AsReadOnly();
+    // The returned collection is not wrapped and the Add method can be called.
+    public ICollection<int> Collection => _collection;
+
+    // The returned collection is wrapped with ReadOnlyCollection which throws an exception when the Add method is called.
+    public ICollection<int> WrappedCollection => _collectionToWrap.AsReadOnly();
 }

--- a/test/Soenneker.Utils.AutoBogus.Tests/Dtos/Simple/TestClassIDictionaryPropertyWrappedWithReadOnly.cs
+++ b/test/Soenneker.Utils.AutoBogus.Tests/Dtos/Simple/TestClassIDictionaryPropertyWrappedWithReadOnly.cs
@@ -4,7 +4,13 @@ namespace Soenneker.Utils.AutoBogus.Tests.Dtos.Simple;
 
 public class TestClassIDictionaryPropertyWrappedWithReadOnly
 {
+    // Both fields are readonly but the dictionaries can be modified.
     private readonly Dictionary<string, string> _dictionary = new();
+    private readonly Dictionary<string, string> _dictionaryToWrap = new();
 
-    public IDictionary<string, string> Dictionary => _dictionary.AsReadOnly();
+    // The returned dictionary is not wrapped and the Add method can be called.
+    public IDictionary<string, string> Dictionary => _dictionary;
+
+    // The returned dictionary is wrapped with ReadOnlyDictionary which throws an exception when the Add method is called.
+    public IDictionary<string, string> WrappedDictionary => _dictionaryToWrap.AsReadOnly();
 }

--- a/test/Soenneker.Utils.AutoBogus.Tests/Dtos/Simple/TestClassIDictionaryPropertyWrappedWithReadOnly.cs
+++ b/test/Soenneker.Utils.AutoBogus.Tests/Dtos/Simple/TestClassIDictionaryPropertyWrappedWithReadOnly.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Soenneker.Utils.AutoBogus.Tests.Dtos.Simple;
+
+public class TestClassIDictionaryPropertyWrappedWithReadOnly
+{
+    private readonly Dictionary<string, string> _dictionary = new();
+
+    public IDictionary<string, string> Dictionary => _dictionary.AsReadOnly();
+}


### PR DESCRIPTION
I ran into a situation with a type that returned a read-only instance through a property exposing a collection interface. Unfortunately, this can be done without declaring a return type that accurately indicates the true read-only nature of the collection.

This PR takes into consideration `IList` or `IDictionary` instances that are `IsReadyOnly` when populating collections. I also added unit tests to assert that no exceptions are thrown during the `Generate` invocation. Because all exceptions are caught and written to the console when populating members, the only option to prove no exception is being thrown in a unit test, was to ensure nothing was written to standard output in addition to checking the collection remained empty.

Props for carrying the torch and creating a viable replacement for AutoBogus. 🙏